### PR TITLE
Make build process easier to extend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 *.dylib
 
 # Executables
+checkrc
 *.exe
 *.out
 *.app

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TARGET = checkrc
 CC = clang
+CFLAGS = -Wall -Werror -Wextra -pedantic -std=c17
 SRCDIR = src
 INCDIR = include
 
@@ -9,11 +10,14 @@ INCLUDES = -I$(INCDIR)
 
 all: $(TARGET)
 
+# main includes config.h, so it needs to depend on it
+main.o: $(INCDIR)/config.h
+
 $(TARGET): $(OBJECTS)
-	$(CC) -o $@ $(OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJECTS)
 
 %.o: $(SRCDIR)/%.c
-	$(CC) $(INCLUDES) -c $< -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)


### PR DESCRIPTION
- gitignore target
- add CFLAGS and LDFLAGS to build so downstreams have an easier time
- record dependencies

It would still be good to convert this to POSIX make, so we don't need GNU make as dependency for the build, but can use any make available.