### PR TITLE
Add a CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  ci-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build+test
+        uses: cross-platform-actions/action@v0.23.0
+        with:
+          operating_system: freebsd
+          version: '14.0'
+          run: |
+            CFLAGS="-O2 -pipe -Wshadow -Werror" make
+            DESTDIR="${HOME}/work" make install
+            ${HOME}/work/usr/local/bin/checkrc /etc/rc.conf

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ SRCS=		main.c \
 		validation_utils.c
 CSTD=		c17
 CFLAGS+=	-I../include
-CWARNFLAGS+=	-Wall -Werror -Wextra -pedantic
+CWARNFLAGS+=	-Wall -Wextra -pedantic
 MAN=		# no manpage yet
 
 # Installation directories


### PR DESCRIPTION
Add a CI build also running the result on FreeBSD 14.0

Enable warnings as errors (-Werror) in CI build, disable it in default CFLAGS (so an updated compiler won't break a "normal" build).

---
Background: Compilers tend to "invent" new warnings with every new release. When treating all warnings as errors with `-Werror`, the build breaks for every user happening to use a newer compiler if there is something new to warn about. So, `-Werror` only makes sense for testing during development. A CI build is a good place for that, therefore add one as an example (running the build in a FreeBSD VM, because the github runners don't offer FreeBSD directly)