### PR TITLE
Implement defaultrouter enhancements

### DIFF
--- a/tests/integration/test_files/invalid_rc.conf
+++ b/tests/integration/test_files/invalid_rc.conf
@@ -1,7 +1,7 @@
 # Invalid rc.conf configuration for testing
 hostname="testserver.local"
-defaultrouter="300.168.1.1"  # Invalid IPv4
-ipv6_defaultrouter="2001:xyz::1"  # Invalid IPv6
+defaultrouter="bad host!"  # Invalid hostname
+ipv6_defaultrouter="2001:db8::g"  # Invalid IPv6
 sshd_enable="enabled"  # Invalid boolean
 ntpd_enable="1"  # Invalid boolean
 rcshutdown_timeout="fast"  # Invalid integer 

--- a/tests/integration/test_files/valid_rc.conf
+++ b/tests/integration/test_files/valid_rc.conf
@@ -1,7 +1,7 @@
 # Valid rc.conf configuration for testing
 hostname="testserver.local"
-defaultrouter="192.168.1.1"
-ipv6_defaultrouter="2001:db8::1"
+defaultrouter="router.example.com"
+ipv6_defaultrouter="fe80::1%em0"
 sshd_enable="YES"
 ntpd_enable="NO"
 rcshutdown_timeout="30" 

--- a/tests/unit/test_validation.c
+++ b/tests/unit/test_validation.c
@@ -4,42 +4,83 @@
 #include "validation_utils.h"
 
 MU_TEST(test_ipv4_validation) {
-    mu_check(validate_option("defaultrouter", "192.168.1.1") == true);
-    mu_check(validate_option("defaultrouter", "10.0.0.1") == true);
-    mu_check(validate_option("defaultrouter", "256.1.2.3") == false);
-    mu_check(validate_option("defaultrouter", "192.168.1") == false);
-    mu_check(validate_option("defaultrouter", "192.168.1.1.1") == false);
-    mu_check(validate_option("defaultrouter", "") == true);  // Empty is valid
+    char v1[] = "192.168.1.1";
+    mu_check(validate_option("defaultrouter", v1) == true);
+    char v2[] = "10.0.0.1";
+    mu_check(validate_option("defaultrouter", v2) == true);
+    char v3[] = "256.1.2.3";
+    mu_check(validate_option("defaultrouter", v3) == false);
+    char v4[] = "192.168.1";
+    mu_check(validate_option("defaultrouter", v4) == false);
+    char v5[] = "192.168.1.1.1";
+    mu_check(validate_option("defaultrouter", v5) == false);
+    char v6[] = "";
+    mu_check(validate_option("defaultrouter", v6) == true);  // Empty is valid
+    char v7[] = "no";
+    mu_check(validate_option("defaultrouter", v7) == true);  // 'no' disables route
+    char v8[] = "router.example.com";
+    mu_check(validate_option("defaultrouter", v8) == true);  // Hostname allowed
+    char v9[] = "bad host!";
+    mu_check(validate_option("defaultrouter", v9) == false);  // Invalid hostname
+    return NULL;
 }
 
 MU_TEST(test_ipv6_validation) {
-    mu_check(validate_option("ipv6_defaultrouter", "2001:db8::1") == true);
-    mu_check(validate_option("ipv6_defaultrouter", "::1") == true);
-    mu_check(validate_option("ipv6_defaultrouter", "2001:db8::g") == false);
-    mu_check(validate_option("ipv6_defaultrouter", "2001:db8:::1") == false);
-    mu_check(validate_option("ipv6_defaultrouter", "") == true);  // Empty is valid
+    char i1[] = "2001:db8::1";
+    mu_check(validate_option("ipv6_defaultrouter", i1) == true);
+    char i2[] = "::1";
+    mu_check(validate_option("ipv6_defaultrouter", i2) == true);
+    char i3[] = "2001:db8::g";
+    mu_check(validate_option("ipv6_defaultrouter", i3) == false);
+    char i4[] = "2001:db8:::1";
+    mu_check(validate_option("ipv6_defaultrouter", i4) == false);
+    char i5[] = "";
+    mu_check(validate_option("ipv6_defaultrouter", i5) == true);  // Empty is valid
+    char i6[] = "no";
+    mu_check(validate_option("ipv6_defaultrouter", i6) == true);
+    char i7[] = "fe80::1%em0";
+    mu_check(validate_option("ipv6_defaultrouter", i7) == true);
+    char i8[] = "gateway.example.com";
+    mu_check(validate_option("ipv6_defaultrouter", i8) == true);
+    return NULL;
 }
 
 MU_TEST(test_boolean_validation) {
-    mu_check(validate_option("sshd_enable", "YES") == true);
-    mu_check(validate_option("sshd_enable", "NO") == true);
-    mu_check(validate_option("sshd_enable", "yes") == true);  // Case insensitive
-    mu_check(validate_option("sshd_enable", "no") == true);   // Case insensitive
-    mu_check(validate_option("sshd_enable", "true") == false);
-    mu_check(validate_option("sshd_enable", "1") == false);
+    char b1[] = "YES";
+    mu_check(validate_option("sshd_enable", b1) == true);
+    char b2[] = "NO";
+    mu_check(validate_option("sshd_enable", b2) == true);
+    char b3[] = "yes";
+    mu_check(validate_option("sshd_enable", b3) == true);  // Case insensitive
+    char b4[] = "no";
+    mu_check(validate_option("sshd_enable", b4) == true);   // Case insensitive
+    char b5[] = "true";
+    mu_check(validate_option("sshd_enable", b5) == false);
+    char b6[] = "1";
+    mu_check(validate_option("sshd_enable", b6) == false);
+    return NULL;
 }
 
 MU_TEST(test_integer_validation) {
-    mu_check(validate_option("rcshutdown_timeout", "30") == true);
-    mu_check(validate_option("rcshutdown_timeout", "-1") == true);
-    mu_check(validate_option("rcshutdown_timeout", "abc") == false);
-    mu_check(validate_option("rcshutdown_timeout", "1.5") == false);
+    char i1[] = "30";
+    mu_check(validate_option("rcshutdown_timeout", i1) == true);
+    char i2[] = "-1";
+    mu_check(validate_option("rcshutdown_timeout", i2) == true);
+    char i3[] = "abc";
+    mu_check(validate_option("rcshutdown_timeout", i3) == false);
+    char i4[] = "1.5";
+    mu_check(validate_option("rcshutdown_timeout", i4) == false);
+    return NULL;
 }
 
 MU_TEST(test_string_validation) {
-    mu_check(validate_option("hostname", "myserver.example.com") == true);
-    mu_check(validate_option("hostname", "") == true);
-    mu_check(validate_option("hostname", "server#1") == true);
+    char s1[] = "myserver.example.com";
+    mu_check(validate_option("hostname", s1) == true);
+    char s2[] = "";
+    mu_check(validate_option("hostname", s2) == true);
+    char s3[] = "server#1";
+    mu_check(validate_option("hostname", s3) == true);
+    return NULL;
 }
 
 MU_TEST_SUITE(test_suite) {


### PR DESCRIPTION
## Summary
- allow hostnames and "no" for defaultrouter/ipv6_defaultrouter
- validate IPv6 addresses with `inet_pton`
- extend unit tests to cover hostnames and interface syntax
- update integration tests

## Testing
- `make test`