### PR TITLE
fix: add release permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
## Summary
- allow CI workflow to create releases by granting contents: write permissions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688f5b4602c483328d92ce9b3f2d7b55